### PR TITLE
Update check-tasks.yml

### DIFF
--- a/.github/workflows/check-tasks.yml
+++ b/.github/workflows/check-tasks.yml
@@ -2,7 +2,7 @@ name: Check Incomplete Task List in PR
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, edited]
 
 permissions:
   checks: write  # Grant permission to create check runs

--- a/.github/workflows/check-tasks.yml
+++ b/.github/workflows/check-tasks.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout repository
-        uses: thanh-doan-cirium/task-list-checker@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v2
 
       # Get the pull request data using GitHub's API
       - name: Run task-list-checker


### PR DESCRIPTION
### Test

## Summary by Sourcery

Modify the GitHub Actions workflow to replace the custom task-list-checker action with the official actions/checkout@v2 action for repository checkout.

CI:
- Update the GitHub Actions workflow to use the official 'actions/checkout@v2' action for checking out the repository.